### PR TITLE
installing murmurhash3 in jruby 1.7.2 explodes on extconf.rb

### DIFF
--- a/ext/murmurhash3/extconf.rb
+++ b/ext/murmurhash3/extconf.rb
@@ -1,4 +1,4 @@
-if RUBY_ENGINE == 'ruby'
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby'
   require 'mkmf'
   create_makefile("native_murmur")
 else


### PR DESCRIPTION
This patch checks to see if RUBY_ENGINE is defined before evaluating it. Tested with jruby 1.7.2 on OSX 10.6.
