### PR TITLE
remove comment from generated noop makefile

### DIFF
--- a/ext/murmurhash3/extconf.rb
+++ b/ext/murmurhash3/extconf.rb
@@ -3,6 +3,6 @@ if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby'
   create_makefile("native_murmur")
 else
   File.open(File.dirname(__FILE__) + "/Makefile", 'w') do |f|
-    f.write("install:\n\t#nothing to build")
+    f.write("install:\n\t")
   end
 end


### PR DESCRIPTION
Installing this gem on a win7 machine using mingw fails because the generated noop Makefile [has a comment](https://github.com/funny-falcon/murmurhash3-ruby/blob/master/ext/murmurhash3/extconf.rb#L6) that is executed:

```
C:\jruby-1.7.17\lib\ruby\gems\shared\gems\murmurhash3-0.1.4\ext\murmurhash3>make

#nothing to build
process_begin: CreateProcess(NULL, #nothing to build, ...) failed.
make (e=2): The system cannot find the file specified.
make: Interrupt/Exception caught (code = 0xc0000005, addr = 0x000007FEFF7D2020)
```

Removing this like fixed it for me.
