### PR TITLE
Include LICENSE file in built gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ spec = Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/funny-falcon/murmurhash3-ruby"
   gem.license       = "MIT"
 
-  files             = FileList['lib/**/*.rb'] + FileList['test/**/*.rb']
+  files             = FileList['lib/**/*.rb', 'test/**/*.rb', 'LICENSE']
   if RUBY_ENGINE == 'jruby'
     gem.files       = files + FileList['ext/**/*.jar']
   else


### PR DESCRIPTION
Per the rubygems guidelines, license files should be included in the
packaged gem. https://guides.rubygems.org/specification-reference/#license=

> The full text of the license should be inside of the gem (at the top level) when you build it.