### PR TITLE
Fix target prefix for native.so

### DIFF
--- a/ext/murmurhash3/extconf.rb
+++ b/ext/murmurhash3/extconf.rb
@@ -1,6 +1,6 @@
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby'
   require 'mkmf'
-  create_makefile("native")
+  create_makefile("murmurhash3/native")
 else
   File.open(File.dirname(__FILE__) + "/Makefile", 'w') do |f|
     f.write("install:\n\t")


### PR DESCRIPTION
The native extension is required in murmurhash3/native_murmur.rb
as 'murmurhash3/native', but it's installed directly into
`$GEM_HOME/extensions/<platform>/<ruby-abi>/murmurhash3-<version>/`,
without murmurhash3 subdirectory. This commit fixes extconf.rb to
install native.so into subdirectory.
Gem has a bad habit of copying native extensions even into
$GEM_HOME/gems/..., where they are not supposed to be installed - that's
why most users haven't noticed this problem. This commit doesn't affect
the other locations, only that in $GEM_HOME/extensions.